### PR TITLE
Add Import Applications Tab to Sidebar

### DIFF
--- a/mayan/apps/sources/apps.py
+++ b/mayan/apps/sources/apps.py
@@ -14,7 +14,7 @@ from mayan.apps.logging.classes import ErrorLog
 from mayan.apps.navigation.classes import SourceColumn
 from mayan.apps.views.html_widgets import TwoStateWidget
 from mayan.apps.common.menus import (
-    menu_list_facet, menu_object, menu_secondary, menu_setup
+    menu_list_facet, menu_object, menu_secondary, menu_setup, menu_main
 )
 
 from .classes import DocumentCreateWizardStep, StagingFile
@@ -31,7 +31,7 @@ from .links import (
     link_setup_source_create_watch_folder, link_setup_source_create_webform,
     link_setup_source_create_staging_folder, link_setup_source_delete,
     link_setup_source_edit, link_staging_file_delete,
-    link_document_file_upload
+    link_document_file_upload, link_application_create_multiple
 )
 from .widgets import StagingFileThumbnailWidget
 
@@ -110,6 +110,8 @@ class SourcesApp(MayanAppConfig):
                 instance=context['object'],
             )
         )
+
+        menu_main.bind_links(links=(link_application_create_multiple,), position=108)
 
         menu_documents.bind_links(links=(link_document_create_multiple,))
 

--- a/mayan/apps/sources/links.py
+++ b/mayan/apps/sources/links.py
@@ -141,3 +141,8 @@ link_setup_source_check_now = Link(
     permissions=(permission_sources_setup_view,), text=_('Check now'),
     view='sources:setup_source_check',
 )
+link_application_create_multiple = Link(
+    condition=condition_document_creation_access,
+    icon=icon_document_file_upload, text=_('Import Applications'),
+    view='sources:application_create_multiple'
+)

--- a/mayan/apps/sources/urls.py
+++ b/mayan/apps/sources/urls.py
@@ -10,7 +10,7 @@ from .views import (
     SourceEditView, SourceListView, StagingFileDeleteView,
     DocumentFileUploadInteractiveView, UploadInteractiveView
 )
-from .wizards import DocumentCreateWizard
+from .wizards import DocumentCreateWizard, ImportApplication
 
 urlpatterns = [
     url(
@@ -23,6 +23,10 @@ urlpatterns = [
     url(
         regex=r'^documents/create/from/local/multiple/$',
         name='document_create_multiple', view=DocumentCreateWizard.as_view()
+    ),
+    url(
+        regex=r'^applications/create/from/local/multiple/$',
+        name='application_create_multiple', view=ImportApplication.as_view()
     ),
     url(
         regex=r'^documents/upload/new/interactive/(?P<source_id>\d+)/$',

--- a/mayan/apps/sources/wizards.py
+++ b/mayan/apps/sources/wizards.py
@@ -99,3 +99,89 @@ class DocumentCreateWizard(SessionWizardView):
         url.args = query_dict
 
         return HttpResponseRedirect(redirect_to=url.tostr())
+
+class ImportApplication(SessionWizardView):
+    template_name = 'appearance/generic_wizard.html'
+
+    @classonlymethod
+    def as_view(cls, *args, **kwargs):
+        # SessionWizardView needs at least one form in order to be
+        # initialized as a view. Declare one empty form and then change the
+        # form list in the .dispatch() method.
+        class EmptyForm(forms.Form):
+            """Empty form"""
+
+        cls.form_list = [EmptyForm]
+        return super().as_view(*args, **kwargs)
+
+    def dispatch(self, request, *args, **kwargs):
+        InteractiveSource = apps.get_model(
+            app_label='sources', model_name='InteractiveSource'
+        )
+
+        form_list = DocumentCreateWizardStep.get_choices(attribute_name='form_class')
+        condition_dict = dict(
+            DocumentCreateWizardStep.get_choices(attribute_name='condition')
+        )
+
+        result = self.__class__.get_initkwargs(
+            condition_dict=condition_dict, form_list=form_list
+        )
+        self.form_list = result['form_list']
+        self.condition_dict = result['condition_dict']
+
+        if not InteractiveSource.objects.filter(enabled=True).exists():
+            messages.error(
+                message=_(
+                    'No interactive document sources have been defined or '
+                    'none have been enabled, create one before proceeding.'
+                ),
+                request=request
+            )
+            return HttpResponseRedirect(
+                redirect_to=reverse(viewname='sources:setup_source_list')
+            )
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form=form, **kwargs)
+
+        wizard_step = DocumentCreateWizardStep.get(name=self.steps.current)
+
+        context.update(
+            {
+                'form_css_classes': 'form-hotkey-double-click',
+                'step_title': _(
+                    'Step %(step)d of %(total_steps)d: %(step_label)s'
+                ) % {
+                    'step': self.steps.step1, 'total_steps': len(self.form_list),
+                    'step_label': wizard_step.label,
+                },
+                'submit_label': _('Next step'),
+                'submit_icon': icon_wizard_submit,
+                'title': _('Import Applications'),
+                'wizard_step': wizard_step,
+                'wizard_steps': DocumentCreateWizardStep.get_all(),
+            }
+        )
+        return context
+
+    def get_form_initial(self, step):
+        return DocumentCreateWizardStep.get(name=step).get_form_initial(wizard=self) or {}
+
+    def get_form_kwargs(self, step):
+        return DocumentCreateWizardStep.get(name=step).get_form_kwargs(wizard=self) or {}
+
+    def done(self, form_list, **kwargs):
+        query_dict = {}
+
+        for step in DocumentCreateWizardStep.get_all():
+            query_dict.update(step.done(wizard=self) or {})
+
+        url = furl(reverse(viewname='sources:document_upload_interactive'))
+        # Use equal and not .update() to get the same result as using
+        # urlencode(doseq=True)
+        url.args = query_dict
+
+        return HttpResponseRedirect(redirect_to=url.tostr())


### PR DESCRIPTION
- Add new tab in menu_main called "Import Applications"
- Create new view for application upload.
- Resolves #6 

To verify that my changes work: 
- Start Mayan-EDMS and click on `Import Applications` on the left sidebar. Try to upload a new document, and then verify if you can see it in the `All Documents` page. 